### PR TITLE
Support keyboard maps that don't align with hardware key codes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,10 +449,11 @@ gen_sin
                 }
 
                 window.addEventListener("keydown", (event) => {
-                    if (event.code == 'KeyS' && (event.metaKey || event.ctrlKey)) {
+                    const keycode = event.key.toLowerCase();
+                    if (keycode == 's' && (event.metaKey || event.ctrlKey)) {
                         event.preventDefault();
                         tryToAssemble();
-                    } else if (event.code == 'KeyH' && (event.metaKey || event.ctrlKey)) {
+                    } else if (keycode == 'h' && (event.metaKey || event.ctrlKey)) {
                         event.preventDefault();
                         if (codeIsHidden()) {
                             showCode();


### PR DESCRIPTION
My keyboard layout does not match its physical layout, meaning that "cmd-s" does not correspond to the key that I type for "s."

This fix ensures the key you type for "s" is the key that is used for "s."

This is maybe a cheeky PR as I am not known for my speccy coding!